### PR TITLE
fix: Escaping Jinja logical statements from assets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -305,12 +305,13 @@ Disabling Jinja Templating
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Both the CLI and Superset support Jinja templating. To prevent the CLI from loading Superset Jinja syntax, the export operation automatically escapes Jinja syntax from YAML files. As a consequence, this query:
+
 .. code-block:: yaml
 
     sql: 'SELECT action, count(*) as times
         FROM logs
         {% if filter_values(''action_type'')|length %}
-            WHERE 1=1
+            WHERE action is null
             {% for action in filter_values(''action_type'') %}
                 or action = ''{{ action }}''
             {% endfor %}
@@ -324,7 +325,7 @@ Becomes this:
     sql: 'SELECT action, count(*) as times
         FROM logs
         {{ '{% if' }} filter_values(''action_type'')|length {{ '%}' }}
-            WHERE 1=1
+            WHERE action is null
             {{ '{% for' }} action in filter_values(''action_type'') {{ '%}' }}
                 or action = ''{{ '{{' }} action {{ '}}' }}''
             {{ '{% endfor %}' }}

--- a/src/preset_cli/cli/superset/sync/native/command.py
+++ b/src/preset_cli/cli/superset/sync/native/command.py
@@ -80,6 +80,16 @@ def is_yaml_config(path: Path) -> bool:
     )
 
 
+def load_yaml(path: Path) -> Dict[str, Any]:
+    """
+    Load a YAML file and returns it as a dictionary.
+    """
+    with open(path, encoding="utf-8") as input_:
+        content = input_.read()
+
+    return yaml.load(content, Loader=yaml.SafeLoader)
+
+
 def render_yaml(path: Path, env: Dict[str, Any]) -> Dict[str, Any]:
     """
     Load a YAML file as a template, render it, and deserialize it.
@@ -109,6 +119,12 @@ def render_yaml(path: Path, env: Dict[str, Any]) -> Dict[str, Any]:
     help="Custom values for templates (eg, country=BR)",
 )
 @click.option(
+    "--disable-jinja-templating",
+    is_flag=True,
+    default=False,
+    help="By default, the CLI supports Jinja templating. This flag disables it",
+)
+@click.option(
     "--disallow-edits",
     is_flag=True,
     default=False,
@@ -135,6 +151,7 @@ def native(  # pylint: disable=too-many-locals, too-many-arguments
     directory: str,
     option: Tuple[str, ...],
     overwrite: bool = False,
+    disable_jinja_templating: bool = False,
     disallow_edits: bool = True,  # pylint: disable=unused-argument
     external_url_prefix: str = "",
     load_env: bool = False,
@@ -171,11 +188,17 @@ def native(  # pylint: disable=too-many-locals, too-many-arguments
         if path_name.is_dir() and not path_name.stem.startswith("."):
             queue.extend(path_name.glob("*"))
         elif is_yaml_config(relative_path):
-            config = render_yaml(path_name, env)
+            if disable_jinja_templating:
+                config = load_yaml(path_name)
+            else:
+                config = render_yaml(path_name, env)
 
             overrides_path = path_name.with_suffix(".overrides" + path_name.suffix)
             if overrides_path.exists():
-                overrides = render_yaml(overrides_path, env)
+                if disable_jinja_templating:
+                    overrides = load_yaml(overrides_path)
+                else:
+                    overrides = render_yaml(overrides_path, env)
                 dict_merge(config, overrides)
 
             config["is_managed_externally"] = disallow_edits

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -40,7 +40,7 @@ def dataset_export() -> BytesIO:
 SELECT action, count(*) as times
 FROM logs
 {% if filter_values('action_type')|length %}
-    WHERE 1=1
+    WHERE action is null
     {% for action in filter_values('action_type') %}
         or action = '{{ action }}'
     {% endfor %}
@@ -100,7 +100,7 @@ def test_export_resource(
 SELECT action, count(*) as times
 FROM logs
 {{ '{% if' }} filter_values('action_type')|length {{ '%}' }}
-    WHERE 1=1
+    WHERE action is null
     {{ '{% for' }} action in filter_values('action_type') {{ '%}' }}
         or action = '{{ '{{' }} action {{ '}}' }}'
     {{ '{% endfor %}' }}
@@ -557,7 +557,7 @@ def test_export_resource_jinja_escaping_disabled(
 SELECT action, count(*) as times
 FROM logs
 {% if filter_values('action_type')|length %}
-    WHERE 1=1
+    WHERE action is null
     {% for action in filter_values('action_type') %}
         or action = '{{ action }}'
     {% endfor %}

--- a/tests/cli/superset/export_test.py
+++ b/tests/cli/superset/export_test.py
@@ -39,8 +39,12 @@ def dataset_export() -> BytesIO:
                 "sql": """
 SELECT action, count(*) as times
 FROM logs
-WHERE
-    action in {{ filter_values('action_type')|where_in }}
+{% if filter_values('action_type')|length %}
+    WHERE 1=1
+    {% for action in filter_values('action_type') %}
+        or action = '{{ action }}'
+    {% endfor %}
+{% endif %}
 GROUP BY action""",
             },
         ),
@@ -75,6 +79,7 @@ def test_export_resource(
         root=root,
         client=client,
         overwrite=False,
+        disable_jinja_escaping=False,
     )
     with open(root / "databases/gsheets.yaml", encoding="utf-8") as input_:
         assert input_.read() == "database_name: GSheets\nsqlalchemy_uri: gsheets://\n"
@@ -86,6 +91,7 @@ def test_export_resource(
         root=root,
         client=client,
         overwrite=False,
+        disable_jinja_escaping=False,
     )
     with open(root / "datasets/gsheets/test.yaml", encoding="utf-8") as input_:
         assert yaml.load(input_.read(), Loader=yaml.SafeLoader) == {
@@ -93,8 +99,12 @@ def test_export_resource(
             "sql": """
 SELECT action, count(*) as times
 FROM logs
-WHERE
-    action in {{ '{{' }} filter_values('action_type')|where_in {{ '}}' }}
+{{ '{% if' }} filter_values('action_type')|length {{ '%}' }}
+    WHERE 1=1
+    {{ '{% for' }} action in filter_values('action_type') {{ '%}' }}
+        or action = '{{ '{{' }} action {{ '}}' }}'
+    {{ '{% endfor %}' }}
+{{ '{% endif %}' }}
 GROUP BY action""",
         }
 
@@ -122,6 +132,7 @@ def test_export_resource_overwrite(
         root=root,
         client=client,
         overwrite=False,
+        disable_jinja_escaping=False,
     )
     with pytest.raises(Exception) as excinfo:
         export_resource(
@@ -130,6 +141,7 @@ def test_export_resource_overwrite(
             root=root,
             client=client,
             overwrite=False,
+            disable_jinja_escaping=False,
         )
     assert str(excinfo.value) == (
         "File already exists and --overwrite was not specified: "
@@ -142,6 +154,7 @@ def test_export_resource_overwrite(
         root=root,
         client=client,
         overwrite=True,
+        disable_jinja_escaping=False,
     )
 
 
@@ -173,6 +186,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 Path("/path/to/root"),
                 client,
                 False,
+                False,
                 skip_related=True,
             ),
             mock.call(
@@ -180,6 +194,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 set(),
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=True,
             ),
@@ -189,6 +204,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 Path("/path/to/root"),
                 client,
                 False,
+                False,
                 skip_related=True,
             ),
             mock.call(
@@ -196,6 +212,7 @@ def test_export_assets(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 set(),
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=True,
             ),
@@ -236,6 +253,7 @@ def test_export_assets_by_id(mocker: MockerFixture, fs: FakeFilesystem) -> None:
                 {1, 2, 3},
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=False,
             ),
@@ -279,6 +297,7 @@ def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> Non
                 Path("/path/to/root"),
                 client,
                 False,
+                False,
                 skip_related=True,
             ),
             mock.call(
@@ -286,6 +305,7 @@ def test_export_assets_by_type(mocker: MockerFixture, fs: FakeFilesystem) -> Non
                 set(),
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=True,
             ),
@@ -321,6 +341,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 Path("/path/to/root"),
                 client,
                 False,
+                False,
                 skip_related=True,
             ),
             mock.call(
@@ -328,6 +349,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 set(),
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=True,
             ),
@@ -337,6 +359,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 Path("/path/to/root"),
                 client,
                 False,
+                False,
                 skip_related=True,
             ),
             mock.call(
@@ -344,6 +367,7 @@ def test_export_with_custom_auth(mocker: MockerFixture, fs: FakeFilesystem) -> N
                 set(),
                 Path("/path/to/root"),
                 client,
+                False,
                 False,
                 skip_related=True,
             ),
@@ -501,3 +525,115 @@ def test_export_ownership(mocker: MockerFixture, fs: FakeFilesystem) -> None:
             },
         ],
     }
+
+
+def test_export_resource_jinja_escaping_disabled(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+    dataset_export: BytesIO,
+) -> None:
+    """
+    Test ``export_resource`` with --disable-jinja-escaping.
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    client = mocker.MagicMock()
+    client.export_zip.return_value = dataset_export
+
+    # check that Jinja2 was not escaped
+    export_resource(
+        resource_name="dataset",
+        requested_ids=set(),
+        root=root,
+        client=client,
+        overwrite=False,
+        disable_jinja_escaping=True,
+    )
+    with open(root / "datasets/gsheets/test.yaml", encoding="utf-8") as input_:
+        assert yaml.load(input_.read(), Loader=yaml.SafeLoader) == {
+            "table_name": "test",
+            "sql": """
+SELECT action, count(*) as times
+FROM logs
+{% if filter_values('action_type')|length %}
+    WHERE 1=1
+    {% for action in filter_values('action_type') %}
+        or action = '{{ action }}'
+    {% endfor %}
+{% endif %}
+GROUP BY action""",
+        }
+
+    # metadata file should be ignored
+    assert not (root / "metadata.yaml").exists()
+
+
+def test_export_resource_jinja_escaping_disabled_command(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test the ``export_assets`` with --disable-jinja-escaping command.
+    """
+    # root must exist for command to succeed
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    SupersetClient = mocker.patch("preset_cli.cli.superset.export.SupersetClient")
+    client = SupersetClient()
+    export_resource = mocker.patch("preset_cli.cli.superset.export.export_resource")
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "export",
+            "/path/to/root",
+            "--disable-jinja-escaping",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    export_resource.assert_has_calls(
+        [
+            mock.call(
+                "database",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                True,
+                skip_related=True,
+            ),
+            mock.call(
+                "dataset",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                True,
+                skip_related=True,
+            ),
+            mock.call(
+                "chart",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                True,
+                skip_related=True,
+            ),
+            mock.call(
+                "dashboard",
+                set(),
+                Path("/path/to/root"),
+                client,
+                False,
+                True,
+                skip_related=True,
+            ),
+        ],
+    )

--- a/tests/cli/superset/main_test.py
+++ b/tests/cli/superset/main_test.py
@@ -135,13 +135,14 @@ Commands:
         == """Usage: superset export [OPTIONS] DIRECTORY
 
 Options:
-  --overwrite           Overwrite existing resources
-  --asset-type TEXT     Asset type
-  --database-ids TEXT   Comma separated list of database IDs to export
-  --dataset-ids TEXT    Comma separated list of dataset IDs to export
-  --chart-ids TEXT      Comma separated list of chart IDs to export
-  --dashboard-ids TEXT  Comma separated list of dashboard IDs to export
-  --help                Show this message and exit.
+  --overwrite               Overwrite existing resources
+  --disable-jinja-escaping  Disable Jinja template escaping
+  --asset-type TEXT         Asset type
+  --database-ids TEXT       Comma separated list of database IDs to export
+  --dataset-ids TEXT        Comma separated list of dataset IDs to export
+  --chart-ids TEXT          Comma separated list of chart IDs to export
+  --dashboard-ids TEXT      Comma separated list of dashboard IDs to export
+  --help                    Show this message and exit.
 """
     )
 

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -807,3 +807,76 @@ def test_import_resources_individually_checkpoint(
     )
 
     assert not Path("checkpoint.log").exists()
+
+
+def test_sync_native_jinja_templating_disabled(
+    mocker: MockerFixture,
+    fs: FakeFilesystem,
+) -> None:
+    """
+    Test ``native`` command with --disable-jinja-templating.
+    """
+    root = Path("/path/to/root")
+    fs.create_dir(root)
+
+    database_config = {
+        "database_name": "GSheets",
+        "sqlalchemy_uri": "gsheets://",
+        "is_managed_externally": False,
+        "uuid": "uuid1",
+    }
+    dataset_config = {
+        "table_name": "test",
+        "is_managed_externally": False,
+        "sql": """
+SELECT action, count(*) as times
+FROM logs
+{% if filter_values('action_type')|length %}
+    WHERE 1=1
+    {% for action in filter_values('action_type') %}
+        or action = '{{ action }}'
+    {% endfor %}
+{% endif %}
+GROUP BY action""",
+    }
+    fs.create_file(
+        root / "databases/gsheets.yaml",
+        contents=yaml.dump(database_config),
+    )
+    fs.create_file(
+        root / "datasets/gsheets/test.yaml",
+        contents=yaml.dump(dataset_config),
+    )
+    fs.create_file(
+        root / "datasets/gsheets/test.overrides.yaml",
+        contents=yaml.dump(dataset_config),
+    )
+
+    SupersetClient = mocker.patch(
+        "preset_cli.cli.superset.sync.native.command.SupersetClient",
+    )
+    client = SupersetClient()
+    client.get_uuids.return_value = {}
+    import_resources = mocker.patch(
+        "preset_cli.cli.superset.sync.native.command.import_resources",
+    )
+    mocker.patch("preset_cli.cli.superset.main.UsernamePasswordAuth")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        superset_cli,
+        [
+            "https://superset.example.org/",
+            "sync",
+            "native",
+            str(root),
+            "--disable-jinja-templating",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    contents = {
+        "bundle/databases/gsheets.yaml": yaml.dump(database_config),
+        "bundle/datasets/gsheets/test.yaml": yaml.dump(dataset_config),
+    }
+    import_resources.assert_has_calls([mock.call(contents, client, False)])

--- a/tests/cli/superset/sync/native/command_test.py
+++ b/tests/cli/superset/sync/native/command_test.py
@@ -832,7 +832,7 @@ def test_sync_native_jinja_templating_disabled(
 SELECT action, count(*) as times
 FROM logs
 {% if filter_values('action_type')|length %}
-    WHERE 1=1
+    WHERE action is null
     {% for action in filter_values('action_type') %}
         or action = '{{ action }}'
     {% endfor %}


### PR DESCRIPTION
This PR implements escaping for Jinja logical statements (https://github.com/preset-io/backend-sdk/issues/188), and also adds two new flags:
* `--disable-jinja-templating`: This flag was added to the `sync native` command, so that the CLI doesn't render any Jinja templating from the assets. This is useful in case the assets contain Jinja and were exported via the UI (and therefore the syntax wasn't escaped).
* `--disable-jinja-escaping`: This flag was added to the `export-assets` command, so that the CLI doesn't escape Jinja syntax from the YAML files. This is useful in case the assets contain Jinja and would be imported through the UI.

Also, these two flags can be used in case the escaping/rendering logic is incorrectly escaping/rendering incorrect values (like JSON curly brackets, etc). 